### PR TITLE
Update Ligurian endonym

### DIFF
--- a/language_metadata/data.tsv
+++ b/language_metadata/data.tsv
@@ -1381,7 +1381,7 @@ lid	lid	<10K	latn	Nyindrou	nyin1250	PG	https://glottolog.org/resource/languoid/i
 lif	lif	800,000	deva,limb	Limbu	limb1266	IN, NP	https://glottolog.org/resource/languoid/id/limb1266		याक्थुङ	https://en.wikipedia.org/w/index.php?title=ISO_639:lif
 lig	lig	10K-100K	latn	Ligbi	ligb1244	CI, GH	https://glottolog.org/resource/languoid/id/ligb1244			https://en.wikipedia.org/w/index.php?title=ISO_639:lig
 lih	lih	10K-100K	latn	Lihir	lihi1237	PG	https://glottolog.org/resource/languoid/id/lihi1237			https://en.wikipedia.org/w/index.php?title=ISO_639:lih
-lij	lij	500,000	latn	Ligurian	ligu1248	FR, IT, MC	https://glottolog.org/resource/languoid/id/ligu1248		Zenéize	https://en.wikipedia.org/w/index.php?title=ISO_639:lij
+lij	lij	500,000	latn	Ligurian	ligu1248	FR, IT, MC	https://glottolog.org/resource/languoid/id/ligu1248		Ligure	https://en.wikipedia.org/w/index.php?title=ISO_639:lij
 lil	lil	<10K	latn	Lillooet	lill1248	CA	https://glottolog.org/resource/languoid/id/lill1248			https://en.wikipedia.org/w/index.php?title=ISO_639:lil
 lim	li	1,000,000	latn	Limburgan	limb1263	BE, DE, NL	https://glottolog.org/resource/languoid/id/limb1263		Limburgs	https://en.wikipedia.org/w/index.php?title=ISO_639:lim
 lin	ln	15,000,000	latn	Kinshasa Lingala	ling1263	CF, CG, CD	https://glottolog.org/resource/languoid/id/ling1263			https://en.wikipedia.org/w/index.php?title=ISO_639:lin


### PR DESCRIPTION
The correct endonym for Ligurian would be _ligure_. That is the inclusive term that denotes the ensemble of Romance varieties spoken traditionally throughout Liguria, Monaco and maybe still some very small parts of Corsica.

What you currently have in the file is an unusual spelling of the endonym for _Genoese_, which is the most widely spoken and understood dialect of Ligurian.

There aren't too many English-language references that discuss this. Perhaps section 2 here will be enough: https://aclanthology.org/2021.udw-1.10.pdf
For a much more thorough reference in Italian, see the following: Fiorenzo Toso (2002). Liguria. In Manlio Cortelazzo, Carla Marcato, and Nicola De Blasi, editors, _I dialetti italiani: storia, struttura, uso_, p. 245–252. UTET, Turin, Italy.