### PR TITLE
Edited erroneous rows in TaTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In particular, this repository contains data related to the following datasets a
 
 - `square_one_bias`: Ruder, S., Vulić, I., & Søgaard, A. (2022). [Square One Bias in NLP: Towards a Multi-Dimensional Exploration of the Research Manifold](https://aclanthology.org/2022.findings-acl.184). In *Findings of the Association for Computational Linguistics: ACL 2022*, 2340–2354.
 
-- `tata`:  Gehrmann, S., Ruder, S., Nikolaev, V., Botha, J. A., Chavinda, M., Parikh, A., & Rivera, C. (2022). TaTA: A Multilingual Table-to-Text Dataset for African Languages. arXiv preprint.
+- `tata`:  Gehrmann, S., Ruder, S., Nikolaev, V., Botha, J. A., Chavinda, M., Parikh, A., & Rivera, C. (2022). [TaTA: A Multilingual Table-to-Text Dataset for African Languages](https://arxiv.org/pdf/2211.00142.pdf). arXiv preprint.
 
 
 - `GATITOS`: Jones, A., Caswell, I., Saxena, I., Firat, O. (2023) [BiLex Rx: Lexical Data Augmentation for Massively Multilingual Machine Translation](https://arxiv.org/pdf/2303.15265.pdf). arXiv preprint.


### PR DESCRIPTION
### Problem

Several rows in **TaTA** contain irregularities in the _table_text_ column. 12 rows have some references which match the data, then several commas in a row (effectively empty references), followed by _"START OF TEXT"_ which I believe was an annotator instruction which wasn't meant to make it into the dataset, and finally some more references which are totally unrelated to the data. There are also some more rows which just have repeating commas.

At least some of the unrelated references appear elsewhere in the dataset. For example, _"Four percent of Tanzanian women age 15-49 reported having two or more sexual partners in the past 12 months."_ appears in example **DM51-en-3**, where it should not be, and also in **SR196-en-3**, where it belongs.

### Solution

I have deleted the commas, annotator tags and incorrect references from the affected rows, and left these amended rows in the dataset so as not to lose training data. I assumed that references after the _"START OF TEXT"_ instruction do not belong there as this is what I observed for the English examples, but I did not verify this for the non-English examples.

I also added a link to the TaTA arXiv preprint to the repo's README, as it was missing.